### PR TITLE
Updated package.json to include mocha.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {<% if (environment === "Node") { %>
-      "chai": "~1.8.0"
+      "chai": "~1.8.0",
+      "mocha":"2.0.1"
   <% } %>},
   "scripts": {<% if (environment === "Node") { %>
     "test": "mocha ./spec/<%= file %>"


### PR DESCRIPTION
In package.json, added mocha as a dependency when using node to test. 
If this generator was used without mocha installed globally the test would fail to run.


###Before
```javascript
  "dependencies": {<% if (environment === "Node") { %>
      "chai": "~1.8.0"
```
###After
```javascript
  "dependencies": {<% if (environment === "Node") { %>
      "chai": "~1.8.0",
      "mocha":"2.0.1"'''
```
