### PR TITLE
Fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # generator-test [![Circle CI](https://circleci.com/gh/phillipalexander/generator-test.png?style=badge)](https://circleci.com/gh/phillipalexander/generator-test)
 
-A simple generator for [Yeoman](http://yeoman.io) that makes it easy to start writing [unit tests](http://en.wikipedia.org/wiki/Unit_testing) and use Test Driven Development (TDD) while you karate-chop your way through algorthim-based programming challenges.
+A simple generator for [Yeoman](http://yeoman.io) that makes it easy to start writing [unit tests](http://en.wikipedia.org/wiki/Unit_testing) and use Test Driven Development (TDD) while you karate-chop your way through algorithm-based programming challenges.
 
 
 ## Introduction


### PR DESCRIPTION
Fixed a typo in the opening paragraph of the README.md. Classic repos such as this one should have proper spelling, lest impressionable new programmers will be led to think it's spelled "algorthim."

Here's the original text:

> A simple generator for Yeoman that makes it easy to start writing unit tests and use Test Driven Development (TDD) while you karate-chop your way through algorthim-based programming challenges.

Here's the updated text:

> A simple generator for Yeoman that makes it easy to start writing unit tests and use Test Driven Development (TDD) while you karate-chop your way through algorithm-based programming challenges.