### PR TITLE
prompt user for assert style

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ After runnning the generator in browser mode, run the tests by opening `index.ht
 
 #### Node
 
-If you select 'Node' when prompted, A simple mocha/chai TDD scaffold for your algorithm solution with the following folder structure will be created:
+If you select 'Node' when prompted, you will be prompted to choose the assert style to use: expect or should. A simple mocha/{chai.expect|should.js} TDD scaffold for your algorithm solution with the following folder structure will be created:
 
 ``` bash
 solution
 ├── node_modules
-│   └── chai
+│   └── {chai|should}
 ├── package.json
 ├── spec
 │   └── algorithm.js

--- a/app/index.js
+++ b/app/index.js
@@ -51,6 +51,15 @@ TestGenerator.prototype.askFor = function askFor() {
     default: 'browser'
   });
 
+  prompts.push({
+    when: function(answers) { return answers.environment === 'Node'; },
+    type: 'list',
+    name: 'assertstyle',
+    message: 'Which assertion style do you want to use?',
+    choices: ['expect', 'should'],
+    default: 'expect'
+  });
+
   if (jsFiles.length === 0) {
     prompts.push({
       name: 'algorithm',
@@ -70,6 +79,7 @@ TestGenerator.prototype.askFor = function askFor() {
     this.file = response.file || response.algorithm + '.js';
     this.algorithm = response.algorithm || response.file.split('.')[0];
     this.environment = response.environment || 'browser';
+    this.assertstyle = response.assertstyle || "expect";
     cb();
   }.bind(this));
 };

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,7 +3,14 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {<% if (environment === "Node") { %>
+    <% switch( assertstyle ) { 
+      case "expect": %>
       "chai": "~1.8.0",
+    <% break;
+      case "should": %>
+      "should": "^7.1.1",
+    <% break;
+    } %>
       "mocha":"2.0.1"
   <% } %>},
   "scripts": {<% if (environment === "Node") { %>

--- a/app/templates/_spec-node.js
+++ b/app/templates/_spec-node.js
@@ -1,5 +1,13 @@
 var path = require('path');
+<% switch(assertstyle) {
+  case "expect":
+  %>
 var expect = require('chai').expect;
+  <% break;
+  case "should":
+  %>
+var should = require('should');
+  <% break;  } %>
 
 var <%= algorithm %> = require(path.join(__dirname, '..', './<%= algorithm %>.js'));
 
@@ -7,16 +15,33 @@ describe('<%= algorithm %>()', function () {
   'use strict';
 
   it('exists', function () {
-    expect(<%= algorithm %>).to.be.a('function');
-
+    <% switch( assertstyle ) { 
+    case "expect": %>
+      expect(<%= algorithm %>).to.be.a('function');
+    <% break; 
+    case "should":%>
+      (typeof <%= algorithm %>).should.not.equal('function');
+    <% break; } %>
   });
 
   it('does something', function () {
-    expect(true).to.equal(false);
+    <% switch( assertstyle ) { 
+    case "expect": %>
+      expect(true).to.equal(false);
+    <% break; 
+    case "should":%>
+      true.should.not.be.ok();
+    <% break; } %>
   });
 
   it('does something else', function () {
-    expect(true).to.equal(false);
+    <% switch( assertstyle ) { 
+    case "expect": %>
+      expect(true).to.equal(false);
+    <% break; 
+    case "should":%>
+      true.should.not.be.ok();
+    <% break; } %>
   });
 
   // Add more assertions here

--- a/test/test-node-assert.js
+++ b/test/test-node-assert.js
@@ -33,7 +33,7 @@ describe('test assertion selector', function () {
         assert.fileContent('algorithm.js', /module\.exports = algorithm/);
         assert.fileContent('./spec/algorithm.js', /require/);
         assert.fileContent('package.json', /should/);
-        assert.fileContent('spec/algorithm.js', /should/);
+        assert.fileContent('./spec/algorithm.js', /should/);
         done();
       });
   });
@@ -59,7 +59,7 @@ describe('test assertion selector', function () {
         assert.fileContent('algorithm.js', /module\.exports = algorithm/);
         assert.fileContent('./spec/algorithm.js', /require/);
         assert.fileContent('package.json', /chai/);
-        assert.fileContent('spec/algorithm.js', /expect/);
+        assert.fileContent('./spec/algorithm.js', /expect/);
         done();
       });
   });

--- a/test/test-node-assert.js
+++ b/test/test-node-assert.js
@@ -1,0 +1,66 @@
+/*global describe, beforeEach, it*/
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+var yeoman = require('yeoman-generator');
+var helpers = yeoman.test;
+var assert = yeoman.assert;
+
+var expectedFiles = ['package.json'];
+var unexpectedFiles = ['bower.json', '.bowerrc'];
+
+describe('test assertion selector', function () {
+
+  it('should generate a test using should style', function (done) {
+    helpers.run(path.join(__dirname, '../app'))
+      .inDir(path.join(__dirname, './temp'))
+      .withOptions({
+        'skip-install': true
+      })
+      .withPrompt({
+        'environment': 'Node',
+        'algorithm': 'algorithm',
+        'assertstyle': 'should'
+      })
+      .on('end', function () {
+        var expected = expectedFiles.concat([
+          'spec/algorithm.js',
+          'algorithm.js'
+        ]);
+        assert.file(expected);
+        assert.noFile(unexpectedFiles);
+        assert.fileContent('algorithm.js', /module\.exports = algorithm/);
+        assert.fileContent('./spec/algorithm.js', /require/);
+        assert.fileContent('package.json', /should/);
+        assert.fileContent('spec/algorithm.js', /should/);
+        done();
+      });
+  });
+
+  it('should generate a test using expect style', function (done) {
+    helpers.run(path.join(__dirname, '../app'))
+      .inDir(path.join(__dirname, './temp'))
+      .withOptions({
+        'skip-install': true
+      })
+      .withPrompt({
+        'environment': 'Node',
+        'algorithm': 'algorithm',
+        'assertstyle': 'expect'
+      })
+      .on('end', function () {
+        var expected = expectedFiles.concat([
+          'spec/algorithm.js',
+          'algorithm.js'
+        ]);
+        assert.file(expected);
+        assert.noFile(unexpectedFiles);
+        assert.fileContent('algorithm.js', /module\.exports = algorithm/);
+        assert.fileContent('./spec/algorithm.js', /require/);
+        assert.fileContent('package.json', /chai/);
+        assert.fileContent('spec/algorithm.js', /expect/);
+        done();
+      });
+  });
+});

--- a/test/test-node-creation.js
+++ b/test/test-node-creation.js
@@ -23,7 +23,8 @@ describe('test node generator', function () {
       })
       .withPrompt({
         'environment': 'Node',
-        'algorithm': 'algorithm'
+        'algorithm': 'algorithm',
+        'assertstyle': 'expect'
       })
       .on('end', function () {
         var expected = expectedFiles.concat([
@@ -47,7 +48,8 @@ describe('test node generator', function () {
       })
       .withPrompt({
         'environment': 'Node',
-        'file': 'myAlgo.js'
+        'file': 'myAlgo.js',
+        'assertstyle': 'expect'
       })
       .on('ready', function (generator) {
         var js = "var myAlgo = function () { return { method: function () {} }; }; module.exports = myAlgo;";
@@ -68,7 +70,7 @@ describe('test node generator', function () {
       });
   });
 
-  it('runs the generated test file in node using npm test', function (done) {
+  it('runs the generated test file in node using npm test + expect style assertions', function (done) {
     helpers.run(path.join(__dirname, '../app'))
       .inDir(path.join(__dirname, './temp'))
       .withOptions({
@@ -76,7 +78,33 @@ describe('test node generator', function () {
       })
       .withPrompt({
         'environment': 'Node',
-        'file': 'myAlgo.js'
+        'file': 'myAlgo.js',
+        'assertstyle': 'expect'
+      })
+      .on('ready', function (generator) {
+        var js = "var myAlgo = function () { return { method: function () {} }; }; module.exports = myAlgo;";
+        fs.writeFileSync(path.join(__dirname, './temp/myAlgo.js'), js);
+      })
+      .on('end', function () {
+        var expected = expectedFiles.concat([
+          'spec/myAlgo.js',
+          'myAlgo.js'
+        ]);
+        assert.fileContent('package.json', /test/);
+        done();
+      });
+  });
+
+  it('runs the generated test file in node using npm test + should style assertions', function (done) {
+    helpers.run(path.join(__dirname, '../app'))
+      .inDir(path.join(__dirname, './temp'))
+      .withOptions({
+        'skip-install': true
+      })
+      .withPrompt({
+        'environment': 'Node',
+        'file': 'myAlgo.js',
+        'assertstyle': 'should'
       })
       .on('ready', function (generator) {
         var js = "var myAlgo = function () { return { method: function () {} }; }; module.exports = myAlgo;";


### PR DESCRIPTION
I like this generator a lot, but I prefer should over chai.expect for my tests. this PR conditionally includes should as a dependency rather than chai, and prompts for the assert style if it's a Node project. the existing tests for a node app is updated to reply to the assertstyle prompt, and new tests written to verify should or expect are used in the generated test